### PR TITLE
Add permissions for scope owners

### DIFF
--- a/permission.py
+++ b/permission.py
@@ -414,7 +414,9 @@ def perm_add_dids(issuer, kwargs, *, session: "Optional[Session]" = None):
                 if rule['account'] != issuer:
                     return False
 
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
+    return _is_root(issuer)\
+        or has_account_attribute(account=issuer, key='admin', session=session)\
+        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)
 
 
 def perm_attach_dids(issuer, kwargs, *, session: "Optional[Session]" = None):
@@ -703,6 +705,7 @@ def perm_add_replicas(issuer, kwargs, *, session: "Optional[Session]" = None):
         or str(kwargs.get('rse', '')).endswith('MOCK')\
         or str(kwargs.get('rse', '')).endswith('LOCALGROUPDISK')\
         or _is_root(issuer)\
+        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)\
         or has_account_attribute(account=issuer, key='admin', session=session)
 
 
@@ -729,7 +732,7 @@ def perm_delete_replicas(issuer, kwargs, *, session: "Optional[Session]" = None)
     """
     return _is_root(issuer)\
         or has_account_attribute(account=issuer, key='admin', session=session)\
-        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)\
+        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)
 
 
 def perm_update_replicas_states(issuer, kwargs, *, session: "Optional[Session]" = None):
@@ -741,7 +744,9 @@ def perm_update_replicas_states(issuer, kwargs, *, session: "Optional[Session]" 
     :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
+    return _is_root(issuer)\
+        or has_account_attribute(account=issuer, key='admin', session=session)\
+        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)\
 
 
 def perm_queue_requests(issuer, kwargs, *, session: "Optional[Session]" = None):


### PR DESCRIPTION
Allow scope owners to  `add_dids`, `add_replicas`, `update_replicas_states`, `delete_replicas`.

Scope owners should already be able to `add_rule` and `add_did`